### PR TITLE
Fix spelling of GraphCool in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install
 npm start
 ```
 
-## GraqhCool
+## GraphCool
 
 I've been using [GraphCool](http://graph.cool) to play around with creating a GraphQL schema to test 
 against. Right now this is configured in src/graphqlCoolClient.js. It's easy enough


### PR DESCRIPTION
Noticed this small typo, figured I'd contribute a fix back.